### PR TITLE
Improved mobile view

### DIFF
--- a/themes/aflyen/static/css/theme.css
+++ b/themes/aflyen/static/css/theme.css
@@ -405,6 +405,10 @@ a:hover {
 }
 
 @media (max-width: 860px) {
+  .site-header {
+    position: static;
+  }
+
   .site-header__inner {
     flex-direction: column;
     align-items: flex-start;
@@ -418,10 +422,10 @@ a:hover {
   .site-nav {
     width: 100%;
     justify-content: flex-start;
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, max-content));
-    column-gap: 0.55rem;
-    row-gap: 0.35rem;
+    display: flex;
+    flex-wrap: nowrap;
+    gap: 0.35rem;
+    overflow-x: auto;
   }
 
   .page-shell {


### PR DESCRIPTION
This pull request updates the responsive styles for the site header and navigation in `theme.css`, improving layout and usability on smaller screens. The main changes adjust positioning and switch the navigation layout from a grid to a horizontally scrollable flexbox.

**Responsive header and navigation improvements:**

* Set `.site-header` to `position: static` on screens narrower than 860px to ensure proper stacking and layout on mobile devices.
* Changed `.site-nav` from a grid layout to a horizontally scrolling flex container, making navigation easier to use on smaller screens and preventing overflow issues.